### PR TITLE
モバイル横長レイアウト改善: パネル幅をmin()で上限付き割合に変更

### DIFF
--- a/frontend/src/app/game/[id]/page.tsx
+++ b/frontend/src/app/game/[id]/page.tsx
@@ -141,7 +141,7 @@ export default function GamePage() {
       {/* Main content */}
       <div className="flex flex-1 overflow-hidden">
         {/* Left panel: online layer (log, dev) */}
-        <div className="w-64 flex-shrink-0 bg-gray-900 border-r border-gray-700 flex flex-col overflow-hidden">
+        <div className="w-64 landscape:w-40 flex-shrink-0 bg-gray-900 border-r border-gray-700 flex flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto p-3">
             <GameLog
               log={log}
@@ -175,7 +175,7 @@ export default function GamePage() {
         </div>
 
         {/* Right panel: catan layer (players, actions) */}
-        <div className="w-72 flex-shrink-0 bg-gray-900 border-l border-gray-700 flex flex-col overflow-hidden">
+        <div className="w-72 landscape:w-48 flex-shrink-0 bg-gray-900 border-l border-gray-700 flex flex-col overflow-hidden">
           <div className="flex-shrink-0 p-3 border-b border-gray-700">
             <PlayerPanel gameState={gameState} myPlayerIdx={myPlayerIdx} sendAction={sendAction} />
           </div>

--- a/frontend/src/app/game/[id]/page.tsx
+++ b/frontend/src/app/game/[id]/page.tsx
@@ -141,7 +141,7 @@ export default function GamePage() {
       {/* Main content */}
       <div className="flex flex-1 overflow-hidden">
         {/* Left panel: online layer (log, dev) */}
-        <div className="w-64 flex-shrink-0 bg-gray-900 border-r border-gray-700 flex flex-col overflow-hidden">
+        <div className="flex-shrink-0 bg-gray-900 border-r border-gray-700 flex flex-col overflow-hidden" style={{ width: 'min(18vw, 256px)' }}>
           <div className="flex-1 overflow-y-auto p-3">
             <GameLog
               log={log}
@@ -175,7 +175,7 @@ export default function GamePage() {
         </div>
 
         {/* Right panel: catan layer (players, actions) */}
-        <div className="w-72 flex-shrink-0 bg-gray-900 border-l border-gray-700 flex flex-col overflow-hidden">
+        <div className="flex-shrink-0 bg-gray-900 border-l border-gray-700 flex flex-col overflow-hidden" style={{ width: 'min(22vw, 288px)' }}>
           <div className="flex-shrink-0 p-3 border-b border-gray-700">
             <PlayerPanel gameState={gameState} myPlayerIdx={myPlayerIdx} sendAction={sendAction} />
           </div>

--- a/frontend/src/app/game/[id]/page.tsx
+++ b/frontend/src/app/game/[id]/page.tsx
@@ -141,7 +141,7 @@ export default function GamePage() {
       {/* Main content */}
       <div className="flex flex-1 overflow-hidden">
         {/* Left panel: online layer (log, dev) */}
-        <div className="w-64 landscape:w-40 flex-shrink-0 bg-gray-900 border-r border-gray-700 flex flex-col overflow-hidden">
+        <div className="w-64 flex-shrink-0 bg-gray-900 border-r border-gray-700 flex flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto p-3">
             <GameLog
               log={log}
@@ -175,7 +175,7 @@ export default function GamePage() {
         </div>
 
         {/* Right panel: catan layer (players, actions) */}
-        <div className="w-72 landscape:w-48 flex-shrink-0 bg-gray-900 border-l border-gray-700 flex flex-col overflow-hidden">
+        <div className="w-72 flex-shrink-0 bg-gray-900 border-l border-gray-700 flex flex-col overflow-hidden">
           <div className="flex-shrink-0 p-3 border-b border-gray-700">
             <PlayerPanel gameState={gameState} myPlayerIdx={myPlayerIdx} sendAction={sendAction} />
           </div>

--- a/frontend/src/components/GameLog.tsx
+++ b/frontend/src/components/GameLog.tsx
@@ -44,7 +44,7 @@ export default function GameLog({ log, chatLog, myPlayerIdx, playerColors, onSen
   };
 
   return (
-    <div className="bg-gray-800 rounded-lg p-3 flex flex-col h-full">
+    <div className="bg-gray-800 rounded-lg p-3 flex flex-col" style={{ height: '480px' }}>
       <h3 className="text-white font-bold text-sm mb-2 flex-shrink-0">ログ / チャット</h3>
       <div className="overflow-y-auto flex-1 space-y-1 mb-2">
         {stream.length === 0 ? (

--- a/frontend/src/components/GameLog.tsx
+++ b/frontend/src/components/GameLog.tsx
@@ -44,7 +44,7 @@ export default function GameLog({ log, chatLog, myPlayerIdx, playerColors, onSen
   };
 
   return (
-    <div className="bg-gray-800 rounded-lg p-3 flex flex-col" style={{ height: '480px' }}>
+    <div className="bg-gray-800 rounded-lg p-3 flex flex-col h-full">
       <h3 className="text-white font-bold text-sm mb-2 flex-shrink-0">ログ / チャット</h3>
       <div className="overflow-y-auto flex-1 space-y-1 mb-2">
         {stream.length === 0 ? (

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,9 +7,6 @@ module.exports = {
   ],
   theme: {
     extend: {
-      screens: {
-        'landscape': { 'raw': '(orientation: landscape) and (max-width: 1023px)' },
-      },
       colors: {
         wood: '#228B22',
         brick: '#8B4513',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,6 +7,9 @@ module.exports = {
   ],
   theme: {
     extend: {
+      screens: {
+        'landscape': { 'raw': '(orientation: landscape) and (max-width: 1023px)' },
+      },
       colors: {
         wood: '#228B22',
         brick: '#8B4513',


### PR DESCRIPTION
## Summary
- 左右パネルの幅を固定ピクセルから`min(vw, 上限px)`に変更し、大画面では現状維持、小画面では縮小するレイアウトを実現
- GameLogの固定高さ480pxを削除し、親コンテナに委任

## 変更内容
- 左パネル: `w-64`(256px固定) → `min(18vw, 256px)`
- 右パネル: `w-72`(288px固定) → `min(22vw, 288px)`
- `GameLog`: `height: 480px` → `h-full`

## 効果
| 画面 | 修正前ボード幅 | 修正後ボード幅 |
|---|---|---|
| iPhone 12 landscape (844px) | 300px | **506px** |
| PC (1440px) | 896px | 896px (変わらず) |